### PR TITLE
FIX Don't use deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
       id: read-nvm
       shell: bash
       run: |
-        echo ::set-output name=version::$(cat .nvmrc)
+        echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
 
     - name: Setup node
       uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.3.0
@@ -52,8 +52,8 @@ runs:
         TEST="false"
         if [[ "$(jq .scripts.lint? package.json)" != "null" ]]; then LINT="true"; fi
         if [[ "$(jq .scripts.test? package.json)" != "null" ]]; then TEST="true"; fi
-        echo "::set-output name=lint::$LINT"
-        echo "::set-output name=test::$TEST"
+        echo "lint=$LINT" >> "$GITHUB_OUTPUT"
+        echo "test=$TEST" >> "$GITHUB_OUTPUT"
         echo "LINT is $LINT"
         echo "TEST is $TEST"
 
@@ -141,7 +141,7 @@ runs:
         CUT=$(echo $GITHUB_REF | cut -c 12-)
         # e.g. pulls/1/update-js-1647810133
         BRANCH=pulls/$CUT/update-js-$(date +%s)
-        echo ::set-output name=branch::$BRANCH
+        echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
     - name: Git
       if: always()


### PR DESCRIPTION
References:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

## Issue
- https://github.com/silverstripe/.github/issues/26