### PR TITLE
DEP Use deps that use node16+

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
 
     - name: Checkout code
-      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Read .nvmrc
       id: read-nvm


### PR DESCRIPTION
For dependencies on a new major release, the only breaking change listed was swapping node version. We shouldn't experience any issues using the new versions.

Also, note that the version of `shivammathur/setup-php` we're using already uses node 16.

# Issue
- https://github.com/silverstripe/gha-ci/issues/50