### PR TITLE
FIX Use CMS 5 compatible webpack command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        NODE_ENV=production node_modules/webpack/bin/webpack.js -p --bail --progress
+        NODE_ENV=production node_modules/.bin/webpack --mode production --bail --progress
 
     - name: Remove any old pull-requests
       if: always()


### PR DESCRIPTION
The -p option was dropped in the version of webpack we used. The command in this pull request is essentially the same as what's used in package.json files for CMS 5
