### PR TITLE
FIX Use github token for curl request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,14 +121,34 @@ runs:
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
-        JSON=$(curl https://api.github.com/repos/$GITHUB_REPOSITORY/branches)
-        BRANCHES=$(echo $JSON | jq -r '.[] | .name | select(.|test("^pulls\/[0-9]\/update-js-[0-9]{10}$"))')
+        # Gets all branches from GitHub API
+        # https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#list-branches
+        RESP_CODE=$(curl -w %{http_code} -s -o __branches.json \
+        -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/branches?per_page=100" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ github.token }}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        )
+        if [[ $RESP_CODE != "200" ]]; then
+          echo "Unable to read list of branches - HTTP response code was $RESP_CODE"
+          cat __branches.json
+          exit 1
+        fi
+        BRANCHES=$(cat __branches.json | jq -r '.[] | .name | select(.|test("^pulls\/[0-9]\/update-js-[0-9]{10}$"))')
         for BRANCH in $BRANCHES; do
           if [[ "$BRANCH" =~ ^pulls/[0-9\.]+/update\-js\-[0-9]+$ ]]; then
             git push origin --delete "$BRANCH"
             echo "Deleted old branch $BRANCH"
           fi
         done
+
+    - name: Delete temporary files
+      shell: bash
+      if: always()
+      run: |
+        if [[ -f __branches.json ]]; then
+          rm __branches.json
+        fi
 
     - name: Generate branch name
       if: always()


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-update-js/issues/20

[This job](https://github.com/silverstripe/silverstripe-segment-field/actions/runs/5921654326/job/16054491179) broke unexpectedly - it happened at the same time as I triggered a large number of 'update-js' workflows on different repos, possibly what happened is the API rate-limit was exceeded

Even if that wasn't the exact reason, I've included `cat __branches.json` in this so if it happens again we'll at least getting an explanation of why it failed