### PR TITLE
FIX Make JS update action compatible with node tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
         echo "framework_supported_major=$FRAMEWORK_SUPPORTED_MAJOR" >> "$GITHUB_OUTPUT"
         # Create a module map of { module_major: cms_version }
         # e.g. for silverstripe/admin it will be { "1": "4", "2": "5", "3": "6" }
-        MODULE_MAP=$(jq -r --arg github_repository "$GITHUB_REPOSITORY" '.supportedModules[] | select(.github == $github_repository) | .majorVersionMapping | to_entries | map({key: .value[0], value: .key}) | from_entries' __repositories.json)
+        MODULE_MAP=$(jq -r --arg github_repository "$GITHUB_REPOSITORY" '(.supportedModules + .misc)[] | select(.github == $github_repository) | .majorVersionMapping | to_entries | map({key: .value[0], value: .key}) | from_entries' __repositories.json)
         echo "MODULE_MAP is $MODULE_MAP"
         rm __repositories.json
         # Work out the CMS version that $DEFAULT_BRANCH maps to
@@ -376,7 +376,11 @@ runs:
       if: inputs.branch_type != 'schedule' && steps.derive-module-branch.outputs.proceed == '1'
       shell: bash
       run: |
-        NODE_ENV=production node_modules/.bin/webpack --mode production --bail --progress
+        if [[ -f node_modules/.bin/webpack-cli ]]; then
+          NODE_ENV=production node_modules/.bin/webpack --mode production --bail --progress
+        else
+          echo "webpack-cli is not installed, skipping webpack build"
+        fi
 
     - name: Remove any old pull-requests
       if: inputs.branch_type != 'schedule' && steps.derive-module-branch.outputs.proceed == '1'
@@ -490,8 +494,20 @@ runs:
           rm __pull_requests.json
         fi
 
-    - name: Derive PR branch name
+    - name: Check for changes
+      id: check-changes
       if: inputs.branch_type != 'schedule' && steps.derive-module-branch.outputs.proceed == '1'
+      shell: bash
+      run: |
+        if [[ -z "$(git status --porcelain)" ]]; then
+          echo "No changes detected, skipping pull-request creation"
+          echo "has_changes=0" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_changes=1" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Derive PR branch name
+      if: inputs.branch_type != 'schedule' && steps.derive-module-branch.outputs.proceed == '1' && steps.check-changes.outputs.has_changes == '1'
       id: derive-pr-branch-name
       shell: bash
       env:
@@ -502,7 +518,7 @@ runs:
         echo "pr_branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
     - name: Git
-      if: inputs.branch_type != 'schedule' && steps.derive-module-branch.outputs.proceed == '1'
+      if: inputs.branch_type != 'schedule' && steps.derive-module-branch.outputs.proceed == '1' && steps.check-changes.outputs.has_changes == '1'
       uses: silverstripe/gha-pull-request@v1
       with:
         branch: ${{ steps.derive-pr-branch-name.outputs.pr_branch }}


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-update-js/issues/43

Tested on forked repo with forked action - https://github.com/emteknetnz/webpack-config/actions/runs/22097440037. I didn't test on eslint-config though I assume these fixes will also be relevant there too.

Three fixes to gha-update-js to support npm-only repos like webpack-config and eslint-config:

1. The action looks up the calling repo's major version mapping from repositories.json but only searches the `supportedModules` array. webpack-config and eslint-config are in the `misc` array instead, so the lookup returns empty and all the downstream branch maths blows up. Fixed by searching both arrays.

2. The webpack build step runs unconditionally but webpack-config doesn't have webpack-cli installed since it's a config library, not something that gets built. Without the CLI, webpack prompts interactively to install it which hangs in CI. Fixed by checking for webpack-cli before running the build.

3. When there are no actual dependency changes (e.g. yarn.lock is identical after a fresh install and there's no build output), the action tries to create a PR with nothing to commit and fails. Fixed by checking for changes before the PR creation steps.